### PR TITLE
Make RabbitMQ Connection More Robust

### DIFF
--- a/sitewhere-rabbit-mq/src/main/java/com/sitewhere/rabbitmq/RabbitMqInboundEventReceiver.java
+++ b/sitewhere-rabbit-mq/src/main/java/com/sitewhere/rabbitmq/RabbitMqInboundEventReceiver.java
@@ -122,12 +122,7 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
 		
 	}
 	/*
-	 *  Connects to RabbitMQ.
-	 *  
-	 *  Will try to reconnect if the initial connection attempt fails. 
-	 *  i.e. RabbitMQ is not reachable on sitewhere/tenant startup
-	 *  
-	 *  Enables automatic recovery of existing connections of amqp client.
+	 *  Connect to RabbitMQ
 	 */
 	private void connect() {
 		
@@ -151,9 +146,9 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
 			
 		    this.channel = connection.createChannel();			
 			
-			LOGGER.info("RabbitMQ receiver connected to: " + getConnectionUri());
+            LOGGER.info("RabbitMQ receiver connected to: " + getConnectionUri());
 
-			channel.queueDeclare(getQueueName(), isDurable(), false, false, null);
+            channel.queueDeclare(getQueueName(), isDurable(), false, false, null);
 
 			LOGGER.info("RabbitMQ receiver using " + (isDurable() ? "durable " : "") + "queue: "
 					+ getQueueName());


### PR DESCRIPTION


Hi Derek,

at the moment the RabbitMQ inbound event processor connection could be made more robust.

Particularly:

    If RabbitMQ is unreachable when sitewhere/sitewhere tenant starts up
    If existing connection is lost for whatever reason, it won't reconnect

Made some changes here to improve robustness. AMQP Client has an automatic reconnect parameter but things get messy considering it is possible for a tenant to be stopped intentionally to update it's configuration so took this approach. Reconnect Interval isn't configurable at the moment, could maybe implement so sort of back-off, 10 second for now.

Have a look and see if it will be any use to you,

Gary.
