### PR TITLE
improve robustness of rabbitmq inbound event receiver connection

### DIFF
--- a/sitewhere-rabbit-mq/src/main/java/com/sitewhere/rabbitmq/RabbitMqInboundEventReceiver.java
+++ b/sitewhere-rabbit-mq/src/main/java/com/sitewhere/rabbitmq/RabbitMqInboundEventReceiver.java
@@ -8,8 +8,11 @@
 package com.sitewhere.rabbitmq;
 
 import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,6 +24,8 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.ShutdownListener;
 import com.sitewhere.device.communication.EventProcessingLogic;
 import com.sitewhere.device.communication.InboundEventReceiver;
 import com.sitewhere.spi.SiteWhereException;
@@ -45,6 +50,9 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
     /** Default number of consumers if not specified */
     private static final int DEFAULT_NUM_CONSUMERS = 5;
 
+    /** Default period in which to attempt connects/re-connects to RabbitMQ */
+    private static final int DEFAULT_RECONNECT_INTERVAL = 10;
+    
     /** Connection URI */
     private String connectionUri = DEFAULT_CONNECTION_URI;
 
@@ -54,9 +62,15 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
     /** Number of consumers to use */
     private int numConsumers = DEFAULT_NUM_CONSUMERS;
 
+    /** Reconnect interval */
+	private int reconnectInterval = DEFAULT_RECONNECT_INTERVAL;
+
     /** Indicates if queue should be durable */
     private boolean durable = false;
 
+    /** RabbitMQ connection factory **/
+    private ConnectionFactory factory;
+    
     /** RabbitMQ connection */
     private Connection connection;
 
@@ -65,6 +79,12 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
 
     /** Used for consumer thread pool */
     private ExecutorService executors;
+    
+    /** Holds reference to scheduled reconnection task */
+    private ScheduledFuture<?> connectionFuture;
+    
+    /** Shedules reconnection attempts */
+    private ScheduledExecutorService connectionExecutor;
 
     /*
      * (non-Javadoc)
@@ -75,34 +95,86 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
      */
     @Override
     public void start(ILifecycleProgressMonitor monitor) throws SiteWhereException {
-	executors = Executors.newFixedThreadPool(getNumConsumers());
-	try {
-	    ConnectionFactory factory = new ConnectionFactory();
-	    factory.setUri(getConnectionUri());
-	    this.connection = factory.newConnection(executors);
-	    this.channel = connection.createChannel();
-
-	    LOGGER.info("RabbitMQ receiver connected to: " + getConnectionUri());
-
-	    channel.queueDeclare(getQueueName(), isDurable(), false, false, null);
-
-	    LOGGER.info("RabbitMQ receiver using " + (isDurable() ? "durable " : "") + "queue: " + getQueueName());
-
-	    // Add consumer callback for channel.
-	    Consumer consumer = new DefaultConsumer(channel) {
-
-		@Override
-		public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties,
-			byte[] body) throws IOException {
-		    EventProcessingLogic.processRawPayload(RabbitMqInboundEventReceiver.this, body, null);
+    	executors = Executors.newFixedThreadPool(getNumConsumers());
+		connectionExecutor = Executors.newScheduledThreadPool(1);
+		factory = new ConnectionFactory();	
+		
+		try{
+			factory.setUri(getConnectionUri());
+		}catch(Exception e){
+			throw new SiteWhereException("Unable to start RabbitMQ event receiver.", e);
 		}
-	    };
-	    channel.basicConsume(getQueueName(), true, consumer);
-	} catch (Exception e) {
-	    throw new SiteWhereException("Unable to start RabbitMQ event receiver.", e);
-	}
+		
+        connect();
     }
 
+    /*
+	 * Schedules a reconnect attempt after network interruption 
+	 */
+	private void scheduleReconnect(){
+		
+		if(connectionFuture != null){
+			connectionFuture.cancel(true);
+		}
+		
+		LOGGER.info("Scheduling reconnect");
+
+		Runnable task = () -> connect();
+		connectionFuture = connectionExecutor.schedule(task, this.getReconnectInterval(), TimeUnit.SECONDS);
+		
+    }
+	
+	
+	/*
+	 *  Connect to RabbitMQ
+	 */
+	private void connect() {
+		
+		try {
+
+			this.connection = factory.newConnection(executors);
+			
+			connection.addShutdownListener(new ShutdownListener() {
+			    public void shutdownCompleted(ShutdownSignalException cause)
+			    {
+			        LOGGER.info("shutdown signal received", cause);
+			        
+			        //Do nothing if SiteWhere initiated the connection close
+			        if(! cause.isInitiatedByApplication()){
+			            connection = null;
+			            scheduleReconnect();
+			        }
+			    }
+			});
+			
+			
+		    this.channel = connection.createChannel();			
+			
+            LOGGER.info("RabbitMQ receiver connected to: " + getConnectionUri());
+
+            channel.queueDeclare(getQueueName(), isDurable(), false, false, null);
+
+			LOGGER.info("RabbitMQ receiver using " + (isDurable() ? "durable " : "") + "queue: "
+					+ getQueueName());
+
+			// Add consumer callback for channel.
+			Consumer consumer = new DefaultConsumer(channel) {
+			    @Override
+				public void handleDelivery(String consumerTag, Envelope envelope,
+						AMQP.BasicProperties properties, byte[] body) throws IOException {
+					EventProcessingLogic.processRawPayload(RabbitMqInboundEventReceiver.this, body, null);
+				}
+			};
+			
+			channel.basicConsume(getQueueName(), true, consumer);
+			
+		} catch(Exception e){
+			LOGGER.error("Connection Error", e);
+			connection = null;
+			scheduleReconnect();
+		}
+		
+    }
     /*
      * (non-Javadoc)
      * 
@@ -112,17 +184,25 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
      */
     @Override
     public void stop(ILifecycleProgressMonitor monitor) throws SiteWhereException {
-	try {
-	    if (channel != null) {
-		channel.close();
-	    }
-	    if (connection != null) {
-		connection.close();
-	    }
-	} catch (Exception e) {
-	    throw new SiteWhereException("Error stopping RabbitMQ event receiver.", e);
-	}
-	executors.shutdownNow();
+        
+        //cancel any reconnection tasks that may be  in progress
+        if(connectionFuture != null && ! connectionFuture.isDone()){
+            connectionFuture.cancel(true);
+        }
+    			
+        try {		
+                if (channel != null) {
+                    channel.close();
+                }
+                if (connection != null) {
+                    connection.close();
+                }
+        } catch (Exception e) {
+            throw new SiteWhereException("Error stopping RabbitMQ event receiver.", e);
+        }
+
+        connectionExecutor.shutdownNow();
+        executors.shutdownNow();
     }
 
     /*
@@ -146,7 +226,15 @@ public class RabbitMqInboundEventReceiver extends InboundEventReceiver<byte[]> {
 	return "RabbitMQ uri=" + getConnectionUri() + " queue=" + getQueueName();
     }
 
-    public String getConnectionUri() {
+    public int getReconnectInterval(){
+        return this.reconnectInterval;
+    }
+
+	public void setReconnectInterval(int reconnectInterval){
+        this.reconnectInterval = reconnectInterval;
+    }
+    
+	public String getConnectionUri() {
 	return connectionUri;
     }
 


### PR DESCRIPTION
Attempts to reconnect if rabbitmq is unreachable at tenant startup or if a live connection is lost . At the moment attempts to reconnect 10 seconds after a previous connection attempt has failed.