### PR TITLE
Influxdb allow creation of user defined tags based on assignment meta…

### DIFF
--- a/sitewhere-influx/src/main/java/com/sitewhere/influx/device/InfluxDbDeviceEvent.java
+++ b/sitewhere-influx/src/main/java/com/sitewhere/influx/device/InfluxDbDeviceEvent.java
@@ -507,6 +507,16 @@ public class InfluxDbDeviceEvent {
     }
 
     /**
+     * Add a tag to an existing object
+     * @param tagName
+     * @param tagValue
+     * @param builder
+     */
+    public static void addUserDefinedTag(String tagName, String tagValue, Point.Builder builder){
+	    builder.tag(tagName, tagValue);
+    }
+
+    /**
      * Parse a date field.
      * 
      * @param values


### PR DESCRIPTION
Allow the user to create tags that will be automatically inserted into influxdb.

Tags should be created as key/value pairs in the assignment metadata.

The tag that the user wants to create should be prefixed with the case sensitive string, INFLUX_TAG_
any remaining characters in the key that remain after INFLUX_TAG_ has been stripped from the start of the string, will be used as the tag name

e.g  a key value pair "INFLUX_TAG_displayName" "myDevice" will result in a tag named displayName with the value myDevice being added to the event data.