### PR TITLE
Influxdb add ability to specify time precision in event meta data

### DIFF
--- a/sitewhere-influx/src/main/java/com/sitewhere/influx/device/InfluxDbDeviceEvent.java
+++ b/sitewhere-influx/src/main/java/com/sitewhere/influx/device/InfluxDbDeviceEvent.java
@@ -73,6 +73,7 @@ public class InfluxDbDeviceEvent {
     /** Event assignmentType field */
     public static final String ASSIGNMENT_TYPE = "assignmenttype";
 
+    /** The meta data field to check if user has specified a time precision */
     private static final String EVENT_TIME_PRECISION_META_DATA_KEY = "precision";
 
     /**

--- a/sitewhere-influx/src/main/java/com/sitewhere/influx/device/InfluxDbDeviceEvent.java
+++ b/sitewhere-influx/src/main/java/com/sitewhere/influx/device/InfluxDbDeviceEvent.java
@@ -69,9 +69,11 @@ public class InfluxDbDeviceEvent {
 
     /** Event metadata field */
     public static final String EVENT_METADATA_PREFIX = "meta:";
-    
+
     /** Event assignmentType field */
     public static final String ASSIGNMENT_TYPE = "assignmenttype";
+
+    private static final String EVENT_TIME_PRECISION_META_DATA_KEY = "precision";
 
     /**
      * Return a builder for the events collection.
@@ -480,13 +482,39 @@ public class InfluxDbDeviceEvent {
 
     /**
      * Save common event fields to builder.
+     * If a precision field is specified in the meta data, the eventDate must be sent
+     * as an appropriate time stamp rather than a human readable string.
+     * 
+     * Valid precisions :   s -  seconds
+     *                      ms - milliseconds
+     *                      mu - microseconds
+     *                      ns - nanoseconds
+     *                      
+     * Default precision is ms - milliseconds if a precision is not specified.
      * 
      * @param event
      * @param builder
      * @throws SiteWhereException
      */
     public static void saveToBuilder(DeviceEvent event, Point.Builder builder) throws SiteWhereException {
-	builder.time(event.getEventDate().getTime(), TimeUnit.MILLISECONDS);
+
+	String timePrecision = event.getMetadata(EVENT_TIME_PRECISION_META_DATA_KEY);
+	TimeUnit precision = TimeUnit.MILLISECONDS;
+
+	if (timePrecision != null) {
+		switch(timePrecision) {
+			case("s")  : {precision = TimeUnit.SECONDS; break;}
+			case("ms") : {precision = TimeUnit.MILLISECONDS; break;}
+			case("mu") : {precision = TimeUnit.MICROSECONDS; break;}
+			case("ns") : {precision = TimeUnit.NANOSECONDS; break;}
+			default: {event.addOrReplaceMetadata(EVENT_TIME_PRECISION_META_DATA_KEY, "ms");}
+			}
+	}
+	else {
+		event.addOrReplaceMetadata(EVENT_TIME_PRECISION_META_DATA_KEY, "ms");
+	}
+
+	builder.time(event.getEventDate().getTime(), precision);
 	builder.addField(EVENT_ID, event.getId());
 	builder.tag(EVENT_TYPE, event.getEventType().name());
 	builder.tag(EVENT_ASSIGNMENT, event.getDeviceAssignmentToken());


### PR DESCRIPTION
Currently the time precision when adding a new event to Influxdb is hard coded to milliseconds.
Less or more precision may be required in particular cases and Influxdb's guidelines are to use as coarse a time precision as appropriate.

One approach is to make this configurable via the UI, however this means that all devices for a given tenant must use the same time resolution whether they require it  or not. I have done an implementation of this, wiring everything up to the Influx config page.

I'll submit this approach first though as it is less obtrusive and only requires a change in the end users behaviour if they want to utilise precisions other than milliseconds.

When sending an event and the user wants to specify the precision they can utilise the meta-data and provide a key  "precision"  with one of the values below. The eventDate field should be present in the message and should take the format of a time stamp rather than a human readable string.

Valid values for "precision"
```
      "s"  = seconds
      "ms"  = milliseconds
      "mu"  = microseconds
      "ns" = nanoseconds
```

eg.
```
    {
       "eventDate" :  1488829520
       "metadata" : {
           "precision" : "s"
        }
    }

   {
       "eventDate" : 1488829520086,
       "metadata" : {
            "precision" : "ms"
        }
   }

    {
       "eventDate" : 1488829522089169
       "metadata" : {
            "precision" : "mu"
        }
   }

    {
        "eventDate" : 1488829522089169239,
        "metadata" : {
            "precision" : "ns"
         }
   }

```

