### PR TITLE
Command Invocation Handle required and non required Parameters

### DIFF
--- a/sitewhere-core-api/src/main/java/com/sitewhere/spi/error/ErrorCode.java
+++ b/sitewhere-core-api/src/main/java/com/sitewhere/spi/error/ErrorCode.java
@@ -229,6 +229,8 @@ public enum ErrorCode {
     /** Operation assumes device is assigned but no assignment exists */
     RequiredCommandParameterMissing(650, "Invocation does not specify a parameter marked as required."),
 
+    /*** Required Parameter does not have a value assigned to it */
+    RequiredCommandParameterValueMissing(651, "Invocation does not assign a value to a required parameter."),
     /********
      * ZONE *
      ********/

--- a/sitewhere-core/src/main/java/com/sitewhere/core/SiteWherePersistence.java
+++ b/sitewhere-core/src/main/java/com/sitewhere/core/SiteWherePersistence.java
@@ -855,17 +855,30 @@ public class SiteWherePersistence {
      * @throws SiteWhereException
      */
     protected static void checkData(ICommandParameter parameter, Map<String, String> values) throws SiteWhereException {
-	// Make sure required fields are passed.
+
+	String value = values.get(parameter.getName());
+	boolean parameterValueIsNull = (value == null);
+	boolean parameterValueIsEmpty = true;
+
+	if (! parameterValueIsNull) {
+	    value = value.trim();
+	    parameterValueIsEmpty = value.length() == 0;
+	}
+
+	//Handle the required parameters first
 	if (parameter.isRequired()) {
-	    if (values.get(parameter.getName()) == null) {
-		throw new SiteWhereException("Required parameter '" + parameter.getName() + "' is missing.");
+		if (parameterValueIsNull) {
+	    throw new SiteWhereException("Required parameter '" + parameter.getName() + "' is missing.");
+	    }
+
+	    if (parameterValueIsEmpty){
+	    throw new SiteWhereException("Required parameter '" + parameter.getName() + "' has no value assigned to it.");
 	    }
 	}
-	// If no value, do not try to validate.
-	String value = values.get(parameter.getName());
-	if (value == null) {
-	    return;
+	else if (parameterValueIsNull || parameterValueIsEmpty) {
+	return;
 	}
+
 	switch (parameter.getType()) {
 	case Fixed32:
 	case Fixed64:
@@ -880,7 +893,7 @@ public class SiteWherePersistence {
 	    try {
 		Long.parseLong(value);
 	    } catch (NumberFormatException e) {
-		throw new SiteWhereException("Parameter '" + parameter.getName() + "' must be numeric.");
+		throw new SiteWhereException("Parameter '" + parameter.getName() + "' must be integral.");
 	    }
 	}
 	case Float: {

--- a/sitewhere-core/src/main/java/com/sitewhere/device/communication/DefaultCommandExecutionBuilder.java
+++ b/sitewhere-core/src/main/java/com/sitewhere/device/communication/DefaultCommandExecutionBuilder.java
@@ -69,10 +69,35 @@ public class DefaultCommandExecutionBuilder extends LifecycleComponent implement
     protected void generateParameters(IDeviceCommandExecution execution) throws SiteWhereException {
 	execution.getParameters().clear();
 	for (ICommandParameter parameter : execution.getCommand().getParameters()) {
+	    //String paramValue = execution.getInvocation().getParameterValues().get(parameter.getName());
+	    
 	    String paramValue = execution.getInvocation().getParameterValues().get(parameter.getName());
-	    if (parameter.isRequired() && (paramValue == null)) {
+		boolean parameterValueIsNull = (paramValue == null);
+		boolean parameterValueIsEmpty = true;
+
+		if (! parameterValueIsNull) {
+		    paramValue = paramValue.trim();
+		    parameterValueIsEmpty = paramValue.length() == 0;
+		}
+		
+		//Handle the required parameters first
+		if (parameter.isRequired()) {
+			if (parameterValueIsNull) {
+				
+		    throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterMissing, ErrorLevel.ERROR);
+		    }
+
+		    if (parameterValueIsEmpty){
+		    throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterValueMissing, ErrorLevel.ERROR);
+		    }
+		}
+		else if (parameterValueIsNull || parameterValueIsEmpty) {
+		continue;
+		}
+		
+	    /*if (parameter.isRequired() && (paramValue == null)) {
 		throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterMissing, ErrorLevel.ERROR);
-	    }
+	    }*/
 	    Object converted = null;
 	    switch (parameter.getType()) {
 	    case Bool: {

--- a/sitewhere-core/src/main/java/com/sitewhere/device/communication/DefaultCommandExecutionBuilder.java
+++ b/sitewhere-core/src/main/java/com/sitewhere/device/communication/DefaultCommandExecutionBuilder.java
@@ -69,35 +69,29 @@ public class DefaultCommandExecutionBuilder extends LifecycleComponent implement
     protected void generateParameters(IDeviceCommandExecution execution) throws SiteWhereException {
 	execution.getParameters().clear();
 	for (ICommandParameter parameter : execution.getCommand().getParameters()) {
-	    //String paramValue = execution.getInvocation().getParameterValues().get(parameter.getName());
-	    
 	    String paramValue = execution.getInvocation().getParameterValues().get(parameter.getName());
-		boolean parameterValueIsNull = (paramValue == null);
-		boolean parameterValueIsEmpty = true;
+	    boolean parameterValueIsNull = (paramValue == null);
+	    boolean parameterValueIsEmpty = true;
 
-		if (! parameterValueIsNull) {
-		    paramValue = paramValue.trim();
-		    parameterValueIsEmpty = paramValue.length() == 0;
-		}
-		
-		//Handle the required parameters first
-		if (parameter.isRequired()) {
-			if (parameterValueIsNull) {
-				
-		    throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterMissing, ErrorLevel.ERROR);
-		    }
+	    if (! parameterValueIsNull) {
+	            paramValue = paramValue.trim();
+	            parameterValueIsEmpty = paramValue.length() == 0;
+	    }
 
-		    if (parameterValueIsEmpty){
-		    throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterValueMissing, ErrorLevel.ERROR);
-		    }
-		}
-		else if (parameterValueIsNull || parameterValueIsEmpty) {
-		continue;
-		}
-		
-	    /*if (parameter.isRequired() && (paramValue == null)) {
-		throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterMissing, ErrorLevel.ERROR);
-	    }*/
+	    //Handle the required parameters first
+	    if (parameter.isRequired()) {
+	        if (parameterValueIsNull) {
+	        throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterMissing, ErrorLevel.ERROR);
+	    }
+
+	    if (parameterValueIsEmpty){
+	        throw new SiteWhereSystemException(ErrorCode.RequiredCommandParameterValueMissing, ErrorLevel.ERROR);
+	        }
+	    }
+	    else if (parameterValueIsNull || parameterValueIsEmpty) {
+	    continue;
+	    }
+
 	    Object converted = null;
 	    switch (parameter.getType()) {
 	    case Bool: {


### PR DESCRIPTION
I know you'll be looking in to this but thought I'd submit my fix for command invocations and for you to use if it is appropriate.


At the moment when a command is issued it is not taken into account whether or not a required or non required parameter has an actual value assigned to it.

```
Should throw an error if:
     required parameter doesn't have a value associated or the value associated with required parameter is invalid
     non- required parameter has a value associated with it and value is invalid

```
