### PR TITLE
check for val being null in ellipsis function

### DIFF
--- a/sitewhere-ui/src/components/common/Utils.js
+++ b/sitewhere-ui/src/components/common/Utils.js
@@ -39,6 +39,9 @@ export default {
 
   // Short string with ellipsis if necessary.
   ellipsis: function (val, max) {
+    if (!val) {
+      return ''
+    }
     return (val.length > max) ? (val.substring(0, max) + '...') : val
   },
 


### PR DESCRIPTION
It's possible that the val parameter is null when being passed to the ellipsis function.

For example: when a user creates a device and doesn't explicitly set a value for "comments" field. When viewing the device list an error is thrown and as a result an "empty space" is shown instead of the information for that particular device.

Putting in a check as per the other function.