### PR TITLE
allow assignment specific retention policy for influx events

### DIFF
--- a/sitewhere-influx/src/main/java/com/sitewhere/influx/InfluxDbDeviceEventManagement.java
+++ b/sitewhere-influx/src/main/java/com/sitewhere/influx/InfluxDbDeviceEventManagement.java
@@ -99,11 +99,8 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
     /** Database name */
     private String database = "sitewhere";
 
-    /** Default retention policy **/
-    private final String DEFAULT_RETENTION_POLICY = "autogen";
-
     /** Retention policy */
-    private String retention = DEFAULT_RETENTION_POLICY;
+    private String retention = "autogen";
 
     /** Indicates if batch delivery is enabled */
     private boolean enableBatch = true;
@@ -286,14 +283,15 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
      * Check if the user has specific a retention policy in the assignment meta-data
      * If so, override the default one.
     */
-    private void setAssignmentSpecificRetentionPolicy(IDeviceAssignment assignment) {
+    private String getAssignmentSpecificRetentionPolicy(IDeviceAssignment assignment) {
 	String policy = assignment.getMetadata(ASSIGNMENT_META_DATA_RETENTION_POLICY);
+
 	if(policy == null) {
-	    setRetention(DEFAULT_RETENTION_POLICY);
+	    return getRetention();
 	 }
-	else{
-	    setRetention(policy);
-	}
+
+	return policy;
+
     }
     /*
      * (non-Javadoc)
@@ -311,9 +309,7 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
 	Point.Builder builder = InfluxDbDeviceEvent.createBuilder();
 	InfluxDbDeviceMeasurements.saveToBuilder(mxs, builder);
 	addUserDefinedTags(assignment, builder);
-	setAssignmentSpecificRetentionPolicy(assignment);
-
-	influx.write(getDatabase(), getRetention(), builder.build());
+	influx.write(getDatabase(), getAssignmentSpecificRetentionPolicy(assignment), builder.build());
 	// Update assignment state if requested.
 	if (measurements.isUpdateState()) {
 	    getAssignmentStateManager().addMeasurements(assignmentToken, mxs);
@@ -366,8 +362,7 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
 	Point.Builder builder = InfluxDbDeviceEvent.createBuilder();
 	InfluxDbDeviceLocation.saveToBuilder(location, builder);
 	addUserDefinedTags(assignment, builder);
-	setAssignmentSpecificRetentionPolicy(assignment);
-	influx.write(getDatabase(), getRetention(), builder.build());
+	influx.write(getDatabase(), getAssignmentSpecificRetentionPolicy(assignment), builder.build());
 
 	// Update assignment state if requested.
 	if (request.isUpdateState()) {
@@ -435,8 +430,7 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
 	Point.Builder builder = InfluxDbDeviceEvent.createBuilder();
 	InfluxDbDeviceAlert.saveToBuilder(alert, builder);
 	addUserDefinedTags(assignment, builder);
-	setAssignmentSpecificRetentionPolicy(assignment);
-	influx.write(getDatabase(), getRetention(), builder.build());
+	influx.write(getDatabase(), getAssignmentSpecificRetentionPolicy(assignment), builder.build());
 
 	// Update assignment state if requested.
 	if (request.isUpdateState()) {
@@ -533,8 +527,7 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
 	Point.Builder builder = InfluxDbDeviceEvent.createBuilder();
 	InfluxDbDeviceCommandInvocation.saveToBuilder(ci, builder);
 	addUserDefinedTags(assignment, builder);
-	setAssignmentSpecificRetentionPolicy(assignment);
-	influx.write(getDatabase(), getRetention(), builder.build());
+	influx.write(getDatabase(), getAssignmentSpecificRetentionPolicy(assignment), builder.build());
 	return ci;
     }
 
@@ -595,8 +588,7 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
 	Point.Builder builder = InfluxDbDeviceEvent.createBuilder();
 	InfluxDbDeviceCommandResponse.saveToBuilder(cr, builder);
 	addUserDefinedTags(assignment, builder);
-	setAssignmentSpecificRetentionPolicy(assignment);
-	influx.write(getDatabase(), getRetention(), builder.build());
+	influx.write(getDatabase(), getAssignmentSpecificRetentionPolicy(assignment), builder.build());
 	return cr;
     }
 
@@ -644,8 +636,7 @@ public class InfluxDbDeviceEventManagement extends TenantLifecycleComponent impl
 	Point.Builder builder = InfluxDbDeviceEvent.createBuilder();
 	InfluxDbDeviceStateChange.saveToBuilder(sc, builder);
 	addUserDefinedTags(assignment, builder);
-	setAssignmentSpecificRetentionPolicy(assignment);
-	influx.write(getDatabase(), getRetention(), builder.build());
+	influx.write(getDatabase(), getAssignmentSpecificRetentionPolicy(assignment), builder.build());
 
 	// Update assignment state if requested.
 	if (request.isUpdateState()) {


### PR DESCRIPTION
Currently all influx events are stored under a global retention policy. 

This means it is difficult to have different levels of retention for data, for example we may only want to keep the raw data from a high producing data source for a short period of time before it is processed, and eventually automatically deleted.

This change allows the retention period to be specified on a per-assignment basis by using the assignment meta-data field as below:

meta-data key                             meta-data value
--------------------                          ---------------------
INFLUX_RETENTION_POLICY  one_week

where one_week is a user defined retention policy that has been created in the influxdb database. At the moment it is the responsibility of the end user to ensure that this retention policy exists in influxdb.

The downside to this is that currently in the UI, when selecting event data to show, the global retention policy is used to retrieve data and thus data under any other retention policy will not be shown in Sitewhere UI, I think though the advantages out weigh this and it can be resolved somewhere down the line in the new Vue.js UI, perhaps by querying influx for retention policies and allowing a specific retention policy to be selected from a drop down list and used as a filter when fetching data to display.