### PR TITLE
add ability for mongodb connection to use ssl

### DIFF
--- a/sitewhere-mongodb/src/main/java/com/sitewhere/mongodb/SiteWhereMongoClient.java
+++ b/sitewhere-mongodb/src/main/java/com/sitewhere/mongodb/SiteWhereMongoClient.java
@@ -57,6 +57,9 @@ public class SiteWhereMongoClient extends TenantLifecycleComponent
     /** Default authentication database name */
     private static final String DEFAULT_AUTH_DATABASE_NAME = "admin";
 
+    /** Default whether to enable ssl for connection */
+    private static final boolean DEFAULT_USE_SSL = false;
+
     /** Mongo client */
     private MongoClient client;
 
@@ -80,6 +83,9 @@ public class SiteWhereMongoClient extends TenantLifecycleComponent
 
     /** Database that holds sitewhere collections */
     private String databaseName = DEFAULT_DATABASE_NAME;
+
+    /** Use ssl for connection */
+    private boolean ssl = DEFAULT_USE_SSL;
 
     /** Database that holds user credentials */
     private String authDatabaseName = DEFAULT_AUTH_DATABASE_NAME;
@@ -166,11 +172,12 @@ public class SiteWhereMongoClient extends TenantLifecycleComponent
     @Override
     public void initialize(ILifecycleProgressMonitor monitor) throws SiteWhereException {
 	try {
-	    MongoClientOptions.Builder builder = new MongoClientOptions.Builder();
+        MongoClientOptions.Builder builder = new MongoClientOptions.Builder();
+	    builder.sslEnabled(getSsl());
 	    builder.maxConnectionIdleTime(60 * 60 * 1000); // 1hour
 
 	    LOGGER.info("MongoDB Connection: hosts=" + getHostname() + " ports=" + getPort() + " replicaSet="
-		    + getReplicaSetName());
+		    + getReplicaSetName() + " ssl = " + getSsl());
 
 	    // Parse hostname(s) and port(s) into address list.
 	    List<ServerAddress> addresses = parseServerAddresses();
@@ -347,6 +354,7 @@ public class SiteWhereMongoClient extends TenantLifecycleComponent
 	messages.add("Hostname: " + hostname);
 	messages.add("Port: " + port);
 	messages.add("Database Name: " + databaseName);
+	messages.add("Use SSL: " + ssl);
 	messages.add("");
 	messages.add("-----------------------");
 	messages.add("-- Device Management --");
@@ -742,6 +750,14 @@ public class SiteWhereMongoClient extends TenantLifecycleComponent
 
     public void setAuthDatabaseName(String authDatabaseName) {
 	this.authDatabaseName = authDatabaseName;
+    }
+
+    public void setSsl(boolean ssl){
+    this.ssl = ssl;
+    }
+
+    public boolean getSsl(){
+    return this.ssl;
     }
 
     public String getDeviceSpecificationsCollectionName() {

--- a/sitewhere-spring-spi/src/main/java/com/sitewhere/spring/handler/ParserUtils.java
+++ b/sitewhere-spring-spi/src/main/java/com/sitewhere/spring/handler/ParserUtils.java
@@ -63,5 +63,10 @@ public class ParserUtils {
 	if (autoConfigureReplication != null) {
 	    client.addPropertyValue("autoConfigureReplication", autoConfigureReplication.getValue());
 	}
+
+	Attr ssl = element.getAttributeNode("ssl");
+	if(ssl != null){
+	    client.addPropertyValue("ssl", ssl.getValue());
+	}
     }
 }

--- a/sitewhere-spring-spi/src/main/resources/META-INF/sitewhere.xsd
+++ b/sitewhere-spring-spi/src/main/resources/META-INF/sitewhere.xsd
@@ -163,6 +163,12 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="ssl" type="xsd:boolean">
+			<xsd:annotation>
+				<xsd:documentation>Indicates whether to use ssl for the connection
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:attributeGroup>
 
 	<!-- Configuration data for an HBase datastore -->


### PR DESCRIPTION
Currently the mongodb connection doesn't use ssl. 

I was trying out connecting to hosted mongodb at https://www.mongodb.com/cloud which by default uses replica sets and ssl.

This change allows specifying ssl as an extra mongodb attribute in sitewhere-server.xml.

After making this change and setting ssl="true"   in sitewhere-server.xml I was able to connect to mongo cloud.

At the moment it can't use the variable substituon "${datastore.ssl}"   as I think you would have to update the schema at http://www.sitewhere.org/schema/sitewhere/ce/current/sitewhere.xsd with the change to made here.

Would be very a useful option to be able to connect to mongo cloud.