### PR TITLE
Support configuration of caching per API channel.

### DIFF
--- a/service-asset-management/src/main/java/com/sitewhere/asset/microservice/AssetManagementMicroservice.java
+++ b/service-asset-management/src/main/java/com/sitewhere/asset/microservice/AssetManagementMicroservice.java
@@ -191,7 +191,7 @@ public class AssetManagementMicroservice
 	this.assetManagementGrpcServer = new AssetManagementGrpcServer(this);
 
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
     }
 
     /*

--- a/service-batch-operations/src/main/java/com/sitewhere/batch/microservice/BatchOperationsMicroservice.java
+++ b/service-batch-operations/src/main/java/com/sitewhere/batch/microservice/BatchOperationsMicroservice.java
@@ -197,10 +197,10 @@ public class BatchOperationsMicroservice
 	this.batchManagementGrpcServer = new BatchManagementGrpcServer(this);
 
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
 
 	// Device event management.
-	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux(true);
     }
 
     /*

--- a/service-command-delivery/src/main/java/com/sitewhere/commands/microservice/CommandDeliveryMicroservice.java
+++ b/service-command-delivery/src/main/java/com/sitewhere/commands/microservice/CommandDeliveryMicroservice.java
@@ -163,7 +163,7 @@ public class CommandDeliveryMicroservice
      */
     private void createGrpcComponents() {
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
     }
 
     /*

--- a/service-device-management/src/main/java/com/sitewhere/device/microservice/DeviceManagementMicroservice.java
+++ b/service-device-management/src/main/java/com/sitewhere/device/microservice/DeviceManagementMicroservice.java
@@ -104,10 +104,10 @@ public class DeviceManagementMicroservice
 	this.deviceManagementGrpcServer = new DeviceManagementGrpcServer(this);
 
 	// Event management microservice connectivity.
-	this.eventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.eventManagementApiDemux = new DeviceEventManagementApiDemux(true);
 
 	// Asset management microservice connectivity.
-	this.assetManagementApiDemux = new AssetManagementApiDemux();
+	this.assetManagementApiDemux = new AssetManagementApiDemux(true);
 
 	// Create step that will start components.
 	ICompositeLifecycleStep init = new CompositeLifecycleStep("Initialize " + getName());

--- a/service-device-registration/src/main/java/com/sitewhere/registration/microservice/DeviceRegistrationMicroservice.java
+++ b/service-device-registration/src/main/java/com/sitewhere/registration/microservice/DeviceRegistrationMicroservice.java
@@ -163,7 +163,7 @@ public class DeviceRegistrationMicroservice
      */
     private void createGrpcComponents() {
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
     }
 
     /*

--- a/service-device-state/src/main/java/com/sitewhere/devicestate/microservice/DeviceStateMicroservice.java
+++ b/service-device-state/src/main/java/com/sitewhere/devicestate/microservice/DeviceStateMicroservice.java
@@ -196,10 +196,10 @@ public class DeviceStateMicroservice extends MultitenantMicroservice<Microservic
 	this.deviceStateGrpcServer = new DeviceStateGrpcServer(this);
 
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
 
 	// Device event management.
-	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux(true);
     }
 
     /*

--- a/service-event-management/src/main/java/com/sitewhere/event/microservice/EventManagementMicroservice.java
+++ b/service-event-management/src/main/java/com/sitewhere/event/microservice/EventManagementMicroservice.java
@@ -191,7 +191,7 @@ public class EventManagementMicroservice
 	this.eventManagementGrpcServer = new EventManagementGrpcServer(this);
 
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
     }
 
     /*

--- a/service-event-sources/src/main/java/com/sitewhere/sources/microservice/EventSourcesMicroservice.java
+++ b/service-event-sources/src/main/java/com/sitewhere/sources/microservice/EventSourcesMicroservice.java
@@ -183,10 +183,10 @@ public class EventSourcesMicroservice extends MultitenantMicroservice<Microservi
      */
     private void createGrpcComponents() {
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
 
 	// Device event management.
-	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux(true);
     }
 
     /*

--- a/service-inbound-processing/src/main/java/com/sitewhere/inbound/microservice/InboundProcessingMicroservice.java
+++ b/service-inbound-processing/src/main/java/com/sitewhere/inbound/microservice/InboundProcessingMicroservice.java
@@ -179,10 +179,10 @@ public class InboundProcessingMicroservice
      */
     private void createGrpcComponents() {
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
 
 	// Device event management.
-	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux(true);
     }
 
     /*

--- a/service-instance-management/src/main/java/com/sitewhere/instance/microservice/InstanceManagementMicroservice.java
+++ b/service-instance-management/src/main/java/com/sitewhere/instance/microservice/InstanceManagementMicroservice.java
@@ -165,8 +165,8 @@ public class InstanceManagementMicroservice extends GlobalMicroservice<Microserv
      * Create components that interact via GRPC.
      */
     protected void createGrpcComponents() {
-	this.userManagementApiDemux = new UserManagementApiDemux();
-	this.tenantManagementApiDemux = new TenantManagementApiDemux();
+	this.userManagementApiDemux = new UserManagementApiDemux(true);
+	this.tenantManagementApiDemux = new TenantManagementApiDemux(true);
     }
 
     /*

--- a/service-label-generation/src/main/java/com/sitewhere/labels/microservice/LabelGenerationMicroservice.java
+++ b/service-label-generation/src/main/java/com/sitewhere/labels/microservice/LabelGenerationMicroservice.java
@@ -195,10 +195,10 @@ public class LabelGenerationMicroservice
      */
     private void createGrpcComponents() {
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
 
 	// Asset management.
-	this.assetManagementApiDemux = new AssetManagementApiDemux();
+	this.assetManagementApiDemux = new AssetManagementApiDemux(true);
     }
 
     /*

--- a/service-outbound-connectors/src/main/java/com/sitewhere/connectors/microservice/OutboundConnectorsMicroservice.java
+++ b/service-outbound-connectors/src/main/java/com/sitewhere/connectors/microservice/OutboundConnectorsMicroservice.java
@@ -180,10 +180,10 @@ public class OutboundConnectorsMicroservice
      */
     private void createGrpcComponents() {
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
 
 	// Device event management.
-	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux(true);
     }
 
     /*

--- a/service-rule-processing/src/main/java/com/sitewhere/rules/microservice/RuleProcessingMicroservice.java
+++ b/service-rule-processing/src/main/java/com/sitewhere/rules/microservice/RuleProcessingMicroservice.java
@@ -180,10 +180,10 @@ public class RuleProcessingMicroservice
      */
     private void createGrpcComponents() {
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(true);
 
 	// Device event management.
-	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux(true);
     }
 
     /*

--- a/service-user-management/src/main/java/com/sitewhere/user/microservice/UserManagementMicroservice.java
+++ b/service-user-management/src/main/java/com/sitewhere/user/microservice/UserManagementMicroservice.java
@@ -252,7 +252,7 @@ public class UserManagementMicroservice extends GlobalMicroservice<MicroserviceI
      */
     protected void createGrpcComponents() {
 	this.userManagementGrpcServer = new UserManagementGrpcServer(this, getUserManagementAccessor());
-	this.tenantManagementApiDemux = new TenantManagementApiDemux();
+	this.tenantManagementApiDemux = new TenantManagementApiDemux(true);
     }
 
     /*

--- a/service-web-rest/src/main/java/com/sitewhere/web/microservice/WebRestMicroservice.java
+++ b/service-web-rest/src/main/java/com/sitewhere/web/microservice/WebRestMicroservice.java
@@ -210,31 +210,31 @@ public class WebRestMicroservice extends GlobalMicroservice<MicroserviceIdentifi
      */
     protected void createGrpcComponents() throws SiteWhereException {
 	// User management.
-	this.userManagementApiDemux = new UserManagementApiDemux();
+	this.userManagementApiDemux = new UserManagementApiDemux(false);
 
 	// Tenant management.
-	this.tenantManagementApiDemux = new TenantManagementApiDemux();
+	this.tenantManagementApiDemux = new TenantManagementApiDemux(false);
 
 	// Device management.
-	this.deviceManagementApiDemux = new DeviceManagementApiDemux();
+	this.deviceManagementApiDemux = new DeviceManagementApiDemux(false);
 
 	// Device event management.
-	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux();
+	this.deviceEventManagementApiDemux = new DeviceEventManagementApiDemux(false);
 
 	// Asset management.
-	this.assetManagementApiDemux = new AssetManagementApiDemux();
+	this.assetManagementApiDemux = new AssetManagementApiDemux(false);
 
 	// Batch management.
-	this.batchManagementApiDemux = new BatchManagementApiDemux();
+	this.batchManagementApiDemux = new BatchManagementApiDemux(false);
 
 	// Schedule management.
-	this.scheduleManagementApiDemux = new ScheduleManagementApiDemux();
+	this.scheduleManagementApiDemux = new ScheduleManagementApiDemux(false);
 
 	// Label generation.
-	this.labelGenerationApiDemux = new LabelGenerationApiDemux();
+	this.labelGenerationApiDemux = new LabelGenerationApiDemux(false);
 
 	// Device state.
-	this.deviceStateApiDemux = new DeviceStateApiDemux();
+	this.deviceStateApiDemux = new DeviceStateApiDemux(false);
     }
 
     /*

--- a/sitewhere-communication/src/test/java/com/sitewhere/communication/test/mqtt/MqttTests.java
+++ b/sitewhere-communication/src/test/java/com/sitewhere/communication/test/mqtt/MqttTests.java
@@ -39,10 +39,10 @@ import com.sitewhere.spi.device.event.AlertSource;
 public class MqttTests {
 
     /** Nunber of threads for multithreaded tests */
-    private static final int NUM_THREADS = 20;
+    private static final int NUM_THREADS = 10;
 
     /** Nunber of calls performed per thread */
-    private static final int NUM_CALLS_PER_THREAD = 10000;
+    private static final int NUM_CALLS_PER_THREAD = 100;
 
     @Test
     public void runMqttTest() throws Exception {
@@ -79,7 +79,7 @@ public class MqttTests {
 	public Void call() throws Exception {
 	    try {
 		this.mqtt = new MQTT();
-		mqtt.setHost("192.168.171.129", 1883);
+		mqtt.setHost("localhost", 1883);
 		this.connection = mqtt.blockingConnection();
 		connection.connect();
 		System.out.println("Connected to: " + mqtt.getHost());
@@ -107,7 +107,7 @@ public class MqttTests {
 	 */
 	public void sendLocationOverMqtt() throws SiteWhereException {
 	    DeviceRequest request = new DeviceRequest();
-	    request.setDeviceToken("99797-RASPBERRYPI-5545473");
+	    request.setDeviceToken("4296-UNO-9749036");
 	    request.setType(Type.DeviceLocation);
 	    DeviceLocationCreateRequest location = new DeviceLocationCreateRequest();
 	    location.setEventDate(new Date());

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/ApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/ApiDemux.java
@@ -69,6 +69,13 @@ public abstract class ApiDemux<T extends IApiChannel> extends TenantEngineLifecy
     /** Discovery monitor pool */
     private ExecutorService discoveryMonitor;
 
+    /** Indicates if channel-level caching is enabled */
+    private boolean cacheEnabled = true;
+
+    public ApiDemux(boolean cacheEnabled) {
+	this.cacheEnabled = cacheEnabled;
+    }
+
     /*
      * @see
      * com.sitewhere.server.lifecycle.LifecycleComponent#start(com.sitewhere.spi.
@@ -310,7 +317,7 @@ public abstract class ApiDemux<T extends IApiChannel> extends TenantEngineLifecy
 	public void run() {
 	    try {
 		getLogger().info(String.format("Creating API channel to address %s.", getHost()));
-		T channel = (T) createApiChannel(getHost());
+		T channel = (T) createApiChannel(getHost(), isCacheEnabled());
 		ILifecycleProgressMonitor monitor = new LifecycleProgressMonitor(
 			new LifecycleProgressContext(1, "Initialize API channel."), getMicroservice());
 
@@ -401,6 +408,18 @@ public abstract class ApiDemux<T extends IApiChannel> extends TenantEngineLifecy
 	public String getHost() {
 	    return host;
 	}
+    }
+
+    /*
+     * @see com.sitewhere.grpc.client.spi.IApiDemux#isCacheEnabled()
+     */
+    @Override
+    public boolean isCacheEnabled() {
+	return cacheEnabled;
+    }
+
+    public void setCacheEnabled(boolean cacheEnabled) {
+	this.cacheEnabled = cacheEnabled;
     }
 
     /*

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/MultitenantApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/MultitenantApiDemux.java
@@ -37,6 +37,10 @@ public abstract class MultitenantApiDemux<T extends IMultitenantApiChannel<?>> e
     /** Keeps track of last time tenant engine was known to be available */
     private Map<String, Map<UUID, Long>> tenantAccessByChannel = new ConcurrentHashMap<>();
 
+    public MultitenantApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see
      * com.sitewhere.grpc.client.ApiDemux#isApiChannelMatch(com.sitewhere.spi.tenant

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/asset/AssetManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/asset/AssetManagementApiDemux.java
@@ -24,6 +24,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class AssetManagementApiDemux extends MultitenantApiDemux<IAssetManagementApiChannel<?>>
 	implements IAssetManagementApiDemux {
 
+    public AssetManagementApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -34,10 +38,17 @@ public class AssetManagementApiDemux extends MultitenantApiDemux<IAssetManagemen
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IAssetManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
-	return new CachedAssetManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
+    public IAssetManagementApiChannel<?> createApiChannel(String host, boolean cacheEnabled) throws SiteWhereException {
+	CachedAssetManagementApiChannel.CacheSettings settings = new CachedAssetManagementApiChannel.CacheSettings();
+	if (!cacheEnabled) {
+	    settings.getAssetTypeConfiguration().setEnabled(false);
+	    settings.getAssetConfiguration().setEnabled(false);
+	}
+	return new CachedAssetManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort(),
+		settings);
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/batch/BatchManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/batch/BatchManagementApiDemux.java
@@ -24,6 +24,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class BatchManagementApiDemux extends MultitenantApiDemux<IBatchManagementApiChannel<?>>
 	implements IBatchManagementApiDemux {
 
+    public BatchManagementApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -34,10 +38,12 @@ public class BatchManagementApiDemux extends MultitenantApiDemux<IBatchManagemen
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IBatchManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
+    public IBatchManagementApiChannel<?> createApiChannel(String host, boolean enableCaching)
+	    throws SiteWhereException {
 	return new BatchManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/cache/AssetManagementCacheProviders.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/cache/AssetManagementCacheProviders.java
@@ -9,6 +9,7 @@ package com.sitewhere.grpc.client.cache;
 
 import java.util.UUID;
 
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
 import com.sitewhere.spi.asset.IAsset;
 import com.sitewhere.spi.asset.IAssetType;
 
@@ -26,8 +27,8 @@ public class AssetManagementCacheProviders {
      */
     public static class AssetTypeByTokenCache extends CacheProvider<String, IAssetType> {
 
-	public AssetTypeByTokenCache() {
-	    super(CacheIdentifier.AssetTypeByToken, String.class, IAssetType.class, 1000, 60);
+	public AssetTypeByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.AssetTypeByToken, String.class, IAssetType.class, configuration);
 	}
     }
 
@@ -38,8 +39,8 @@ public class AssetManagementCacheProviders {
      */
     public static class AssetTypeByIdCache extends CacheProvider<UUID, IAssetType> {
 
-	public AssetTypeByIdCache() {
-	    super(CacheIdentifier.AssetTypeById, UUID.class, IAssetType.class, 1000, 60);
+	public AssetTypeByIdCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.AssetTypeById, UUID.class, IAssetType.class, configuration);
 	}
     }
 
@@ -50,8 +51,8 @@ public class AssetManagementCacheProviders {
      */
     public static class AssetByTokenCache extends CacheProvider<String, IAsset> {
 
-	public AssetByTokenCache() {
-	    super(CacheIdentifier.AssetByToken, String.class, IAsset.class, 10000, 60);
+	public AssetByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.AssetByToken, String.class, IAsset.class, configuration);
 	}
     }
 
@@ -62,8 +63,8 @@ public class AssetManagementCacheProviders {
      */
     public static class AssetByIdCache extends CacheProvider<UUID, IAsset> {
 
-	public AssetByIdCache() {
-	    super(CacheIdentifier.AssetById, UUID.class, IAsset.class, 10000, 60);
+	public AssetByIdCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.AssetById, UUID.class, IAsset.class, configuration);
 	}
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/cache/CacheConfiguration.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/cache/CacheConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) SiteWhere, LLC. All rights reserved. http://www.sitewhere.com
+ *
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package com.sitewhere.grpc.client.cache;
+
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
+
+/**
+ * Provides settings which control how a cache is to be configured.
+ */
+public class CacheConfiguration implements ICacheConfiguration {
+
+    /** Maximum number of cache entries */
+    private int maximumSize;
+
+    /** Max life of cache entries in seconds */
+    private int ttlInSeconds;
+
+    /** Indicates if cache is enabled */
+    private boolean enabled;
+
+    public CacheConfiguration(int maximumSize, int ttlInSeconds) {
+	this.maximumSize = maximumSize;
+	this.ttlInSeconds = ttlInSeconds;
+	this.enabled = true;
+    }
+
+    /*
+     * @see com.sitewhere.grpc.client.spi.cache.ICacheConfiguration#getMaximumSize()
+     */
+    @Override
+    public int getMaximumSize() {
+	return maximumSize;
+    }
+
+    /*
+     * @see
+     * com.sitewhere.grpc.client.spi.cache.ICacheConfiguration#setMaximumSize(int)
+     */
+    @Override
+    public void setMaximumSize(int maximumSize) {
+	this.maximumSize = maximumSize;
+    }
+
+    /*
+     * @see
+     * com.sitewhere.grpc.client.spi.cache.ICacheConfiguration#getTtlInSeconds()
+     */
+    @Override
+    public int getTtlInSeconds() {
+	return ttlInSeconds;
+    }
+
+    /*
+     * @see
+     * com.sitewhere.grpc.client.spi.cache.ICacheConfiguration#setTtlInSeconds(int)
+     */
+    @Override
+    public void setTtlInSeconds(int ttlInSeconds) {
+	this.ttlInSeconds = ttlInSeconds;
+    }
+
+    /*
+     * @see com.sitewhere.grpc.client.spi.cache.ICacheConfiguration#isEnabled()
+     */
+    @Override
+    public boolean isEnabled() {
+	return enabled;
+    }
+
+    /*
+     * @see
+     * com.sitewhere.grpc.client.spi.cache.ICacheConfiguration#setEnabled(boolean)
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+	this.enabled = enabled;
+    }
+}

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/cache/DeviceManagementCacheProviders.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/cache/DeviceManagementCacheProviders.java
@@ -9,6 +9,7 @@ package com.sitewhere.grpc.client.cache;
 
 import java.util.UUID;
 
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
 import com.sitewhere.spi.area.IArea;
 import com.sitewhere.spi.device.IDevice;
 import com.sitewhere.spi.device.IDeviceAssignment;
@@ -28,8 +29,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class AreaByTokenCache extends CacheProvider<String, IArea> {
 
-	public AreaByTokenCache() {
-	    super(CacheIdentifier.AreaByToken, String.class, IArea.class, 1000, 60);
+	public AreaByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.AreaByToken, String.class, IArea.class, configuration);
 	}
     }
 
@@ -40,8 +41,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class AreaByIdCache extends CacheProvider<UUID, IArea> {
 
-	public AreaByIdCache() {
-	    super(CacheIdentifier.AreaById, UUID.class, IArea.class, 1000, 60);
+	public AreaByIdCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.AreaById, UUID.class, IArea.class, configuration);
 	}
     }
 
@@ -52,8 +53,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class DeviceTypeByTokenCache extends CacheProvider<String, IDeviceType> {
 
-	public DeviceTypeByTokenCache() {
-	    super(CacheIdentifier.DeviceByToken, String.class, IDeviceType.class, 1000, 60);
+	public DeviceTypeByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.DeviceByToken, String.class, IDeviceType.class, configuration);
 	}
     }
 
@@ -64,8 +65,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class DeviceTypeByIdCache extends CacheProvider<UUID, IDeviceType> {
 
-	public DeviceTypeByIdCache() {
-	    super(CacheIdentifier.DeviceTypeById, UUID.class, IDeviceType.class, 1000, 60);
+	public DeviceTypeByIdCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.DeviceTypeById, UUID.class, IDeviceType.class, configuration);
 	}
     }
 
@@ -76,8 +77,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class DeviceByTokenCache extends CacheProvider<String, IDevice> {
 
-	public DeviceByTokenCache() {
-	    super(CacheIdentifier.DeviceByToken, String.class, IDevice.class, 10000, 30);
+	public DeviceByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.DeviceByToken, String.class, IDevice.class, configuration);
 	}
     }
 
@@ -88,8 +89,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class DeviceByIdCache extends CacheProvider<UUID, IDevice> {
 
-	public DeviceByIdCache() {
-	    super(CacheIdentifier.DeviceById, UUID.class, IDevice.class, 10000, 30);
+	public DeviceByIdCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.DeviceById, UUID.class, IDevice.class, configuration);
 	}
     }
 
@@ -100,8 +101,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class DeviceAssignmentByTokenCache extends CacheProvider<String, IDeviceAssignment> {
 
-	public DeviceAssignmentByTokenCache() {
-	    super(CacheIdentifier.DeviceAssignmentByToken, String.class, IDeviceAssignment.class, 10000, 30);
+	public DeviceAssignmentByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.DeviceAssignmentByToken, String.class, IDeviceAssignment.class, configuration);
 	}
     }
 
@@ -112,8 +113,8 @@ public class DeviceManagementCacheProviders {
      */
     public static class DeviceAssignmentByIdCache extends CacheProvider<UUID, IDeviceAssignment> {
 
-	public DeviceAssignmentByIdCache() {
-	    super(CacheIdentifier.DeviceAssignmentById, UUID.class, IDeviceAssignment.class, 10000, 30);
+	public DeviceAssignmentByIdCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.DeviceAssignmentById, UUID.class, IDeviceAssignment.class, configuration);
 	}
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/device/CachedDeviceManagementApiChannel.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/device/CachedDeviceManagementApiChannel.java
@@ -9,8 +9,10 @@ package com.sitewhere.grpc.client.device;
 
 import java.util.UUID;
 
+import com.sitewhere.grpc.client.cache.CacheConfiguration;
 import com.sitewhere.grpc.client.cache.DeviceManagementCacheProviders;
 import com.sitewhere.grpc.client.spi.IApiDemux;
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
 import com.sitewhere.grpc.client.spi.cache.ICacheProvider;
 import com.sitewhere.security.UserContextManager;
 import com.sitewhere.spi.SiteWhereException;
@@ -52,16 +54,20 @@ public class CachedDeviceManagementApiChannel extends DeviceManagementApiChannel
     /** Device assignment by id cache */
     private ICacheProvider<UUID, IDeviceAssignment> deviceAssignmentByIdCache;
 
-    public CachedDeviceManagementApiChannel(IApiDemux<?> demux, String host, int port) {
+    public CachedDeviceManagementApiChannel(IApiDemux<?> demux, String host, int port, CacheSettings settings) {
 	super(demux, host, port);
-	this.areaCache = new DeviceManagementCacheProviders.AreaByTokenCache();
-	this.areaByIdCache = new DeviceManagementCacheProviders.AreaByIdCache();
-	this.deviceTypeCache = new DeviceManagementCacheProviders.DeviceTypeByTokenCache();
-	this.deviceTypeByIdCache = new DeviceManagementCacheProviders.DeviceTypeByIdCache();
-	this.deviceCache = new DeviceManagementCacheProviders.DeviceByTokenCache();
-	this.deviceByIdCache = new DeviceManagementCacheProviders.DeviceByIdCache();
-	this.deviceAssignmentCache = new DeviceManagementCacheProviders.DeviceAssignmentByTokenCache();
-	this.deviceAssignmentByIdCache = new DeviceManagementCacheProviders.DeviceAssignmentByIdCache();
+	this.areaCache = new DeviceManagementCacheProviders.AreaByTokenCache(settings.getAreaConfiguration());
+	this.areaByIdCache = new DeviceManagementCacheProviders.AreaByIdCache(settings.getAreaConfiguration());
+	this.deviceTypeCache = new DeviceManagementCacheProviders.DeviceTypeByTokenCache(
+		settings.getDeviceTypeConfiguration());
+	this.deviceTypeByIdCache = new DeviceManagementCacheProviders.DeviceTypeByIdCache(
+		settings.getDeviceTypeConfiguration());
+	this.deviceCache = new DeviceManagementCacheProviders.DeviceByTokenCache(settings.getDeviceConfiguration());
+	this.deviceByIdCache = new DeviceManagementCacheProviders.DeviceByIdCache(settings.getDeviceConfiguration());
+	this.deviceAssignmentCache = new DeviceManagementCacheProviders.DeviceAssignmentByTokenCache(
+		settings.getDeviceAssignmentConfiguration());
+	this.deviceAssignmentByIdCache = new DeviceManagementCacheProviders.DeviceAssignmentByIdCache(
+		settings.getDeviceAssignmentConfiguration());
     }
 
     /*
@@ -240,6 +246,56 @@ public class CachedDeviceManagementApiChannel extends DeviceManagementApiChannel
 	    getDeviceAssignmentByIdCache().setCacheEntry(tenant, id, assignment);
 	}
 	return assignment;
+    }
+
+    /**
+     * Contains default cache settings for device management entities.
+     */
+    public static class CacheSettings {
+
+	/** Cache configuraton for areas */
+	private ICacheConfiguration areaConfiguration = new CacheConfiguration(1000, 60);
+
+	/** Cache configuration for device types */
+	private ICacheConfiguration deviceTypeConfiguration = new CacheConfiguration(1000, 30);
+
+	/** Cache configuration for devices */
+	private ICacheConfiguration deviceConfiguration = new CacheConfiguration(10000, 30);
+
+	/** Cache configuration for device assignments */
+	private ICacheConfiguration deviceAssignmentConfiguration = new CacheConfiguration(10000, 30);
+
+	public ICacheConfiguration getAreaConfiguration() {
+	    return areaConfiguration;
+	}
+
+	public void setAreaConfiguration(ICacheConfiguration areaConfiguration) {
+	    this.areaConfiguration = areaConfiguration;
+	}
+
+	public ICacheConfiguration getDeviceTypeConfiguration() {
+	    return deviceTypeConfiguration;
+	}
+
+	public void setDeviceTypeConfiguration(ICacheConfiguration deviceTypeConfiguration) {
+	    this.deviceTypeConfiguration = deviceTypeConfiguration;
+	}
+
+	public ICacheConfiguration getDeviceConfiguration() {
+	    return deviceConfiguration;
+	}
+
+	public void setDeviceConfiguration(ICacheConfiguration deviceConfiguration) {
+	    this.deviceConfiguration = deviceConfiguration;
+	}
+
+	public ICacheConfiguration getDeviceAssignmentConfiguration() {
+	    return deviceAssignmentConfiguration;
+	}
+
+	public void setDeviceAssignmentConfiguration(ICacheConfiguration deviceAssignmentConfiguration) {
+	    this.deviceAssignmentConfiguration = deviceAssignmentConfiguration;
+	}
     }
 
     public ICacheProvider<String, IArea> getAreaCache() {

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/device/DeviceManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/device/DeviceManagementApiDemux.java
@@ -24,6 +24,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class DeviceManagementApiDemux extends MultitenantApiDemux<IDeviceManagementApiChannel<?>>
 	implements IDeviceManagementApiDemux {
 
+    public DeviceManagementApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -34,10 +38,20 @@ public class DeviceManagementApiDemux extends MultitenantApiDemux<IDeviceManagem
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IDeviceManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
-	return new CachedDeviceManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
+    public IDeviceManagementApiChannel<?> createApiChannel(String host, boolean cacheEnabled)
+	    throws SiteWhereException {
+	CachedDeviceManagementApiChannel.CacheSettings settings = new CachedDeviceManagementApiChannel.CacheSettings();
+	if (!cacheEnabled) {
+	    settings.getAreaConfiguration().setEnabled(false);
+	    settings.getDeviceTypeConfiguration().setEnabled(false);
+	    settings.getDeviceConfiguration().setEnabled(false);
+	    settings.getDeviceAssignmentConfiguration().setEnabled(false);
+	}
+	return new CachedDeviceManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort(),
+		settings);
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/devicestate/DeviceStateApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/devicestate/DeviceStateApiDemux.java
@@ -24,6 +24,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class DeviceStateApiDemux extends MultitenantApiDemux<IDeviceStateApiChannel<?>>
 	implements IDeviceStateApiDemux {
 
+    public DeviceStateApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -34,10 +38,11 @@ public class DeviceStateApiDemux extends MultitenantApiDemux<IDeviceStateApiChan
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IDeviceStateApiChannel<?> createApiChannel(String host) throws SiteWhereException {
+    public IDeviceStateApiChannel<?> createApiChannel(String host, boolean enableCaching) throws SiteWhereException {
 	return new DeviceStateApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/event/DeviceEventManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/event/DeviceEventManagementApiDemux.java
@@ -25,6 +25,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class DeviceEventManagementApiDemux extends MultitenantApiDemux<IDeviceEventManagementApiChannel<?>>
 	implements IDeviceEventManagementApiDemux {
 
+    public DeviceEventManagementApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -35,10 +39,12 @@ public class DeviceEventManagementApiDemux extends MultitenantApiDemux<IDeviceEv
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IDeviceEventManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
+    public IDeviceEventManagementApiChannel<?> createApiChannel(String host, boolean enableCaching)
+	    throws SiteWhereException {
 	return new DeviceEventManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/label/LabelGenerationApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/label/LabelGenerationApiDemux.java
@@ -24,6 +24,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class LabelGenerationApiDemux extends MultitenantApiDemux<ILabelGenerationApiChannel<?>>
 	implements ILabelGenerationApiDemux {
 
+    public LabelGenerationApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -34,10 +38,12 @@ public class LabelGenerationApiDemux extends MultitenantApiDemux<ILabelGeneratio
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public ILabelGenerationApiChannel<?> createApiChannel(String host) throws SiteWhereException {
+    public ILabelGenerationApiChannel<?> createApiChannel(String host, boolean enableCaching)
+	    throws SiteWhereException {
 	return new LabelGenerationApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/microservice/MicroserviceManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/microservice/MicroserviceManagementApiDemux.java
@@ -28,6 +28,7 @@ public class MicroserviceManagementApiDemux extends ApiDemux<IMicroserviceManage
     private IFunctionIdentifier targetIdentifier;
 
     public MicroserviceManagementApiDemux(IFunctionIdentifier targetIdentifier) {
+	super(false);
 	this.targetIdentifier = targetIdentifier;
     }
 
@@ -41,10 +42,12 @@ public class MicroserviceManagementApiDemux extends ApiDemux<IMicroserviceManage
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IMicroserviceManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
+    public IMicroserviceManagementApiChannel<?> createApiChannel(String host, boolean enableCaching)
+	    throws SiteWhereException {
 	return new MicroserviceManagementApiChannel(this, host,
 		getMicroservice().getInstanceSettings().getManagementGrpcPort());
     }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/schedule/ScheduleManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/schedule/ScheduleManagementApiDemux.java
@@ -24,6 +24,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class ScheduleManagementApiDemux extends MultitenantApiDemux<IScheduleManagementApiChannel<?>>
 	implements IScheduleManagementApiDemux {
 
+    public ScheduleManagementApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -34,10 +38,12 @@ public class ScheduleManagementApiDemux extends MultitenantApiDemux<IScheduleMan
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IScheduleManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
+    public IScheduleManagementApiChannel<?> createApiChannel(String host, boolean enableCaching)
+	    throws SiteWhereException {
 	return new ScheduleManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/spi/IApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/spi/IApiDemux.java
@@ -31,6 +31,13 @@ public interface IApiDemux<T extends IApiChannel> extends ITenantEngineLifecycle
     public IFunctionIdentifier getTargetIdentifier();
 
     /**
+     * Indicates if channel-level caching is enabled.
+     * 
+     * @return
+     */
+    public boolean isCacheEnabled();
+
+    /**
      * Wait for an instance of the remote microservice to become available. This
      * does not guarantee that tenant engines are available.
      */
@@ -55,10 +62,11 @@ public interface IApiDemux<T extends IApiChannel> extends ITenantEngineLifecycle
      * Create an API channel to the given host.
      * 
      * @param host
+     * @param cacheEnabled
      * @return
      * @throws SiteWhereException
      */
-    public T createApiChannel(String host) throws SiteWhereException;
+    public T createApiChannel(String host, boolean cacheEnabled) throws SiteWhereException;
 
     /**
      * Initialize a new API channel for the given host.

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/spi/cache/ICacheConfiguration.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/spi/cache/ICacheConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) SiteWhere, LLC. All rights reserved. http://www.sitewhere.com
+ *
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package com.sitewhere.grpc.client.spi.cache;
+
+/**
+ * Provides settings which control how a cache is to be configured.
+ */
+public interface ICacheConfiguration {
+
+    /**
+     * Get maximum size for cache.
+     * 
+     * @return
+     */
+    public int getMaximumSize();
+
+    /**
+     * Set maximum size for cache.
+     * 
+     * @param value
+     */
+    public void setMaximumSize(int value);
+
+    /**
+     * Get time to live in seconds.
+     * 
+     * @return
+     */
+    public int getTtlInSeconds();
+
+    /**
+     * Set time to live in seconds.
+     * 
+     * @param value
+     */
+    public void setTtlInSeconds(int value);
+
+    /**
+     * Indicates whether cache is enabled.
+     * 
+     * @return
+     */
+    public boolean isEnabled();
+
+    /**
+     * Set cache enablement.
+     * 
+     * @param value
+     */
+    public void setEnabled(boolean value);
+}

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/spi/cache/ICacheProvider.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/spi/cache/ICacheProvider.java
@@ -30,18 +30,11 @@ public interface ICacheProvider<K, V> extends ILifecycleComponent {
     public CacheIdentifier getCacheIdentifier();
 
     /**
-     * Get maximum size for cache.
+     * Get cache configuration settings.
      * 
      * @return
      */
-    public int getMaximumSize();
-
-    /**
-     * Get time to live in seconds.
-     * 
-     * @return
-     */
-    public int getTtlInSeconds();
+    public ICacheConfiguration getCacheConfiguration();
 
     /**
      * Set a cache entry.

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/tenant/CachedTenantManagementApiChannel.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/tenant/CachedTenantManagementApiChannel.java
@@ -9,7 +9,9 @@ package com.sitewhere.grpc.client.tenant;
 
 import java.util.UUID;
 
+import com.sitewhere.grpc.client.cache.CacheConfiguration;
 import com.sitewhere.grpc.client.spi.IApiDemux;
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
 import com.sitewhere.grpc.client.spi.cache.ICacheProvider;
 import com.sitewhere.spi.SiteWhereException;
 import com.sitewhere.spi.server.lifecycle.ILifecycleProgressMonitor;
@@ -28,10 +30,11 @@ public class CachedTenantManagementApiChannel extends TenantManagementApiChannel
     /** Tenant by id cache */
     private ICacheProvider<UUID, ITenant> tenantByIdCache;
 
-    public CachedTenantManagementApiChannel(IApiDemux<?> demux, String host, int port) {
+    public CachedTenantManagementApiChannel(IApiDemux<?> demux, String host, int port, CacheSettings settings) {
 	super(demux, host, port);
-	this.tenantByTokenCache = new TenantManagementCacheProviders.TenantByTokenCache();
-	this.tenantByIdCache = new TenantManagementCacheProviders.TenantByIdCache();
+	this.tenantByTokenCache = new TenantManagementCacheProviders.TenantByTokenCache(
+		settings.getTenantConfiguration());
+	this.tenantByIdCache = new TenantManagementCacheProviders.TenantByIdCache(settings.getTenantConfiguration());
     }
 
     /*
@@ -98,6 +101,23 @@ public class CachedTenantManagementApiChannel extends TenantManagementApiChannel
 	    getTenantByTokenCache().setCacheEntry(null, token, tenant);
 	}
 	return tenant;
+    }
+
+    /**
+     * Contains default cache settings for tenant management entities.
+     */
+    public static class CacheSettings {
+
+	/** Cache configuraton for tenants */
+	private ICacheConfiguration tenantConfiguration = new CacheConfiguration(1000, 60);
+
+	public ICacheConfiguration getTenantConfiguration() {
+	    return tenantConfiguration;
+	}
+
+	public void setTenantConfiguration(ICacheConfiguration tenantConfiguration) {
+	    this.tenantConfiguration = tenantConfiguration;
+	}
     }
 
     public ICacheProvider<String, ITenant> getTenantByTokenCache() {

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/tenant/TenantManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/tenant/TenantManagementApiDemux.java
@@ -24,6 +24,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
 public class TenantManagementApiDemux extends ApiDemux<ITenantManagementApiChannel<?>>
 	implements ITenantManagementApiDemux {
 
+    public TenantManagementApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -34,10 +38,17 @@ public class TenantManagementApiDemux extends ApiDemux<ITenantManagementApiChann
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public ITenantManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
-	return new CachedTenantManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
+    public ITenantManagementApiChannel<?> createApiChannel(String host, boolean cacheEnabled)
+	    throws SiteWhereException {
+	CachedTenantManagementApiChannel.CacheSettings settings = new CachedTenantManagementApiChannel.CacheSettings();
+	if (!cacheEnabled) {
+	    settings.getTenantConfiguration().setEnabled(false);
+	}
+	return new CachedTenantManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort(),
+		settings);
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/tenant/TenantManagementCacheProviders.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/tenant/TenantManagementCacheProviders.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 import com.sitewhere.grpc.client.cache.CacheIdentifier;
 import com.sitewhere.grpc.client.cache.CacheProvider;
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
 import com.sitewhere.spi.tenant.ITenant;
 
 /**
@@ -27,8 +28,8 @@ public class TenantManagementCacheProviders {
      */
     public static class TenantByTokenCache extends CacheProvider<String, ITenant> {
 
-	public TenantByTokenCache() {
-	    super(CacheIdentifier.TenantByToken, String.class, ITenant.class, 100, 60);
+	public TenantByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.TenantByToken, String.class, ITenant.class, configuration);
 	}
     }
 
@@ -39,8 +40,8 @@ public class TenantManagementCacheProviders {
      */
     public static class TenantByIdCache extends CacheProvider<UUID, ITenant> {
 
-	public TenantByIdCache() {
-	    super(CacheIdentifier.TenantById, UUID.class, ITenant.class, 100, 60);
+	public TenantByIdCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.TenantById, UUID.class, ITenant.class, configuration);
 	}
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/user/CachedUserManagementApiChannel.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/user/CachedUserManagementApiChannel.java
@@ -9,7 +9,9 @@ package com.sitewhere.grpc.client.user;
 
 import java.util.List;
 
+import com.sitewhere.grpc.client.cache.CacheConfiguration;
 import com.sitewhere.grpc.client.spi.IApiDemux;
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
 import com.sitewhere.grpc.client.spi.cache.ICacheProvider;
 import com.sitewhere.spi.SiteWhereException;
 import com.sitewhere.spi.server.lifecycle.ILifecycleProgressMonitor;
@@ -30,10 +32,11 @@ public class CachedUserManagementApiChannel extends UserManagementApiChannel {
     /** Granted authority cache */
     private ICacheProvider<String, List> grantedAuthorityCache;
 
-    public CachedUserManagementApiChannel(IApiDemux<?> demux, String host, int port) {
+    public CachedUserManagementApiChannel(IApiDemux<?> demux, String host, int port, CacheSettings settings) {
 	super(demux, host, port);
-	this.userCache = new UserManagementCacheProviders.UserByTokenCache();
-	this.grantedAuthorityCache = new UserManagementCacheProviders.GrantedAuthorityByTokenCache();
+	this.userCache = new UserManagementCacheProviders.UserByTokenCache(settings.getUserConfiguration());
+	this.grantedAuthorityCache = new UserManagementCacheProviders.GrantedAuthorityByTokenCache(
+		settings.getUserConfiguration());
     }
 
     /*
@@ -101,6 +104,23 @@ public class CachedUserManagementApiChannel extends UserManagementApiChannel {
 	    getGrantedAuthorityCache().setCacheEntry(null, username, auths);
 	}
 	return auths;
+    }
+
+    /**
+     * Contains default cache settings for user management entities.
+     */
+    public static class CacheSettings {
+
+	/** Cache configuraton for users */
+	private ICacheConfiguration userConfiguration = new CacheConfiguration(1000, 60);
+
+	public ICacheConfiguration getUserConfiguration() {
+	    return userConfiguration;
+	}
+
+	public void setUserConfiguration(ICacheConfiguration userConfiguration) {
+	    this.userConfiguration = userConfiguration;
+	}
     }
 
     public ICacheProvider<String, IUser> getUserCache() {

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/user/UserManagementApiDemux.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/user/UserManagementApiDemux.java
@@ -23,6 +23,10 @@ import com.sitewhere.spi.microservice.MicroserviceIdentifier;
  */
 public class UserManagementApiDemux extends ApiDemux<IUserManagementApiChannel<?>> implements IUserManagementApiDemux {
 
+    public UserManagementApiDemux(boolean cacheEnabled) {
+	super(cacheEnabled);
+    }
+
     /*
      * @see com.sitewhere.grpc.client.spi.IApiDemux#getTargetIdentifier()
      */
@@ -33,10 +37,16 @@ public class UserManagementApiDemux extends ApiDemux<IUserManagementApiChannel<?
 
     /*
      * @see
-     * com.sitewhere.grpc.model.spi.IApiDemux#createApiChannel(java.lang.String)
+     * com.sitewhere.grpc.client.spi.IApiDemux#createApiChannel(java.lang.String,
+     * boolean)
      */
     @Override
-    public IUserManagementApiChannel<?> createApiChannel(String host) throws SiteWhereException {
-	return new CachedUserManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort());
+    public IUserManagementApiChannel<?> createApiChannel(String host, boolean cacheEnabled) throws SiteWhereException {
+	CachedUserManagementApiChannel.CacheSettings settings = new CachedUserManagementApiChannel.CacheSettings();
+	if (!cacheEnabled) {
+	    settings.getUserConfiguration().setEnabled(false);
+	}
+	return new CachedUserManagementApiChannel(this, host, getMicroservice().getInstanceSettings().getGrpcPort(),
+		settings);
     }
 }

--- a/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/user/UserManagementCacheProviders.java
+++ b/sitewhere-grpc-client/src/main/java/com/sitewhere/grpc/client/user/UserManagementCacheProviders.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import com.sitewhere.grpc.client.cache.CacheIdentifier;
 import com.sitewhere.grpc.client.cache.CacheProvider;
+import com.sitewhere.grpc.client.spi.cache.ICacheConfiguration;
 import com.sitewhere.spi.user.IUser;
 
 /**
@@ -27,8 +28,8 @@ public class UserManagementCacheProviders {
      */
     public static class UserByTokenCache extends CacheProvider<String, IUser> {
 
-	public UserByTokenCache() {
-	    super(CacheIdentifier.UserByToken, String.class, IUser.class, 100, 60);
+	public UserByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.UserByToken, String.class, IUser.class, configuration);
 	}
     }
 
@@ -40,8 +41,8 @@ public class UserManagementCacheProviders {
     @SuppressWarnings("rawtypes")
     public static class GrantedAuthorityByTokenCache extends CacheProvider<String, List> {
 
-	public GrantedAuthorityByTokenCache() {
-	    super(CacheIdentifier.GrantedAuthorityByToken, String.class, List.class, 100, 60);
+	public GrantedAuthorityByTokenCache(ICacheConfiguration configuration) {
+	    super(CacheIdentifier.GrantedAuthorityByToken, String.class, List.class, configuration);
 	}
     }
 }

--- a/sitewhere-microservice/src/main/java/com/sitewhere/microservice/multitenant/MultitenantMicroservice.java
+++ b/sitewhere-microservice/src/main/java/com/sitewhere/microservice/multitenant/MultitenantMicroservice.java
@@ -113,7 +113,7 @@ public abstract class MultitenantMicroservice<I extends IFunctionIdentifier, T e
      * Create components that interact via GRPC.
      */
     private void createGrpcComponents() {
-	this.tenantManagementApiDemux = new TenantManagementApiDemux();
+	this.tenantManagementApiDemux = new TenantManagementApiDemux(true);
     }
 
     /*


### PR DESCRIPTION
Different microservices may have specific caching requirements for the data consumed from external services. Support configuration at the API channel level for whether caching is used. Turn off caching on web/REST service so that it always deals with non-cached information.